### PR TITLE
Typo correction

### DIFF
--- a/_posts/2013-02-07-introducing-csswizardry-grids.md
+++ b/_posts/2013-02-07-introducing-csswizardry-grids.md
@@ -37,7 +37,7 @@ It works on the principle of percentages, rather than absolute columns, meaning
 that there are no confusing `.span-6` classes that behave like `.span-12` ones
 at smaller sizes.
 
-The grids are aslo fully (infinitely) nestable, meaning you can apply sizing to
+The grids are also fully (infinitely) nestable, meaning you can apply sizing to
 your sub-components as well as to your page-level layout. Furthermore,
 csswizardry-grids’ implementation is left entirely up to you, with two options:
 


### PR DESCRIPTION
"aslo" to "also" on the "Introducing csswizardry-grids"  post.
