### PR TITLE
Update dotfiles link

### DIFF
--- a/uses.md
+++ b/uses.md
@@ -148,7 +148,7 @@ I use a bunch of handy tools from the command line on a daily basis:
 ### Dotfiles
 
 I host [my dotfiles on
-GitHub](https://github.com/csswizardry/dotfiles/blob/master/.vimrc), if you’re
+GitHub](https://github.com/csswizardry/dotfiles/), if you’re
 interested in taking a look. There’s nothing really remarkable in most of them.
 
 ### Chrome


### PR DESCRIPTION
Currently links to a specific file (`.vimrc`), thought it would be a minor improvement to link to the top level.