### PR TITLE
Remove note about `no-transform` being ineffective over HTTPS

### DIFF
--- a/_posts/2019-03-04-cache-control-for-civilians.md
+++ b/_posts/2019-03-04-cache-control-for-civilians.md
@@ -328,10 +328,6 @@ other directives for it to function itself.
 Brotli encoding for users that need the former or could use the latter; image
 transformation services automatically converting to WebP; etc.
 
-**N.B.** If you’re running over HTTPS—which you should be—then intermediaries
-and proxies can’t modify payloads anyway, so `no-transform` would be
-ineffective.
-
 {% include promo.html %}
 
 - - -


### PR DESCRIPTION
Google's [Web Light](https://support.google.com/webmasters/answer/6211428?hl=en) may transform secure pages, as explained in https://bugs.chromium.org/p/chromium/issues/detail?id=941948#c8, thus it'd be inaccurate to say that `Cache-Control: no-transform` is ineffective over https (notably Web Light does respect the `no-transform` directive).