### PR TITLE
Add note about using print media type hack with a CSP

### DIFF
--- a/_posts/2020-05-19-the-fastest-google-fonts.md
+++ b/_posts/2020-05-19-the-fastest-google-fonts.md
@@ -638,3 +638,14 @@ Here is the optimum snippet to use for fast Google Fonts:
         href="$CSS&display=swap" />
 </noscript>
 {% endhighlight %}
+
+## Using Async CSS with a CSP
+
+If you're using a Content Security Policy and you don't want to use the
+`unsafe-inline` keyword, you can use a SHA-256 hash together with the
+`unsafe-hashes` keyword instead:
+
+{% highlight http %}
+Content-Security-Policy: script-src
+    'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=';
+{% endhighlight %}


### PR DESCRIPTION
Rouge will highlight HTTP responses, but it requires a status line to work, or it treats the entire highlight as an error.

If you prefix the snippet with `HTTP/1.1 200 OK` then the highlighting works as expected.

Compare [with status line](http://rouge.jneen.net/v3.19.0/http/SFRUUC8xLjEgMjAwIE9LCkNvbnRlbnQtU2VjdXJpdHktUG9saWN5OiBzY3JpcHQtc3JjCiAgICAndW5zYWZlLWhhc2hlcycgJ3NoYTI1Ni1NaHRQWlhyNytMcEpVWTVxdE11dEIrcVdmUXRNYVBjY2ZlN1FYdENjRVljPSc7) vs [without status line](http://rouge.jneen.net/v3.19.0/http/Q29udGVudC1TZWN1cml0eS1Qb2xpY3k6IHNjcmlwdC1zcmMKICAgICd1bnNhZmUtaGFzaGVzJyAnc2hhMjU2LU1odFBaWHI3K0xwSlVZNXF0TXV0QitxV2ZRdE1hUGNjZmU3UVh0Q2NFWWM9Jzs).